### PR TITLE
Fix/add timestamp to testsuites xml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,7 @@ jobs:
         working-directory: client
         run: make build_${{ matrix.goos }} VERSION=${{ needs.precheck.outputs.version }} COMMIT=$(git rev-parse HEAD)
       - name: Test
-        run: make test_${{ matrix.goos }
+        run: make test_${{ matrix.goos }}
       - name: 'Archive debug toscactl'
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
         run: make build_${{ matrix.goos }} VERSION=${{ needs.precheck.outputs.version }} COMMIT=$(git rev-parse HEAD)
       - name: Test
         working-directory: client
-        run: make test_${{ matrix.goos }}
+        run: make test
       - name: 'Archive debug toscactl'
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,6 +173,7 @@ jobs:
         working-directory: client
         run: make build_${{ matrix.goos }} VERSION=${{ needs.precheck.outputs.version }} COMMIT=$(git rev-parse HEAD)
       - name: Test
+        working-directory: client
         run: make test_${{ matrix.goos }}
       - name: 'Archive debug toscactl'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,11 +150,17 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           require_tests: true
 
-
+  test_toscactl:
+    runs-on: [ubuntu-20.04]
+    needs: [precheck]
+    steps:
+      - name: Test
+        working-directory: client
+        run: make test
           
   build_toscactl:
     runs-on: [ubuntu-20.04]
-    needs: [precheck]
+    needs: [precheck, test_toscactl]
     strategy:
       matrix:
         goos: [linux, windows, darwin]
@@ -172,9 +178,6 @@ jobs:
       - name: Build
         working-directory: client
         run: make build_${{ matrix.goos }} VERSION=${{ needs.precheck.outputs.version }} COMMIT=$(git rev-parse HEAD)
-      - name: Test
-        working-directory: client
-        run: make test
       - name: 'Archive debug toscactl'
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,6 +154,12 @@ jobs:
     runs-on: [ubuntu-20.04]
     needs: [precheck]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v1        
+      - name: Setup GO
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.16' # The Go version to download (if necessary) and use.
       - name: Test
         working-directory: client
         run: make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,6 +172,8 @@ jobs:
       - name: Build
         working-directory: client
         run: make build_${{ matrix.goos }} VERSION=${{ needs.precheck.outputs.version }} COMMIT=$(git rev-parse HEAD)
+      - name: Test
+        run: make test_${{ matrix.goos }
       - name: 'Archive debug toscactl'
         uses: actions/upload-artifact@v2
         with:

--- a/client/Makefile
+++ b/client/Makefile
@@ -21,6 +21,18 @@ build_darwin: build_prepare
 	cd $(SRC_DIR)
 	GOOS=darwin go build -v $(BUILD_ARGS) -o $(BUILD_DIR)/toscactl-darwin-amd64 .
 
+test_linux: 
+	cd $(SRC_DIR)
+	GOOS=linux go test -v ./...
+
+test_windows: 
+	cd $(SRC_DIR)
+	GOOS=windows go test -v ./...
+
+test_darwin: 
+	cd $(SRC_DIR)
+	GOOS=darwin go test -v ./...
+
 clean:
 	rm -rf "$(BUILD_DIR)"
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -21,17 +21,9 @@ build_darwin: build_prepare
 	cd $(SRC_DIR)
 	GOOS=darwin go build -v $(BUILD_ARGS) -o $(BUILD_DIR)/toscactl-darwin-amd64 .
 
-test_linux: 
+test: 
 	cd $(SRC_DIR)
-	GOOS=linux go test -v ./...
-
-test_windows: 
-	cd $(SRC_DIR)
-	GOOS=windows go test -v ./...
-
-test_darwin: 
-	cd $(SRC_DIR)
-	GOOS=darwin go test -v ./...
+	go test -v ./...
 
 clean:
 	rm -rf "$(BUILD_DIR)"

--- a/client/src/go/toscactl/entity/configuration.go
+++ b/client/src/go/toscactl/entity/configuration.go
@@ -64,7 +64,7 @@ func (selectorMap *KeyValue) String() string {
 func (selectorMap *KeyValue) Set(value string) error {
 	keyValue:=strings.Split(value,"=")
 	if len(keyValue) <= 1 {
-		return fmt.Errorf("invalid format %s expected labelName=labelValue")
+		return fmt.Errorf("invalid format %s expected labelName=labelValue", value)
 	}
 	(*selectorMap)[keyValue[0]]=keyValue[1]
 	return nil

--- a/client/src/go/toscactl/test/test_data/original.xml
+++ b/client/src/go/toscactl/test/test_data/original.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<testsuites>
+  <testsuite name="Acceptance" tests="3" failures="1" errors="2" time="24" skipped="0" hostname="example.machine" id="0-0-0-0">
+    <testcase name="tcase1" time="1" classname="Acceptance" status="">
+      <failure type="ExecutionResultState.Error" message="TestCase Failed with Error" />
+      <system-out>	some text </system-out>
+    </testcase>
+    <testcase name="tcase2" time="11" classname="Acceptance">
+      <error type="ExecutionResultState.Failed" message="TestCase Failed with Failure" />
+      <system-out>	more text </system-out>
+    </testcase>
+    <testcase name="tcase3" time="11" classname="Acceptance">
+      <error type="ExecutionResultState.Failed" message="TestCase Failed with Failure" />
+      <system-out>	even more text </system-out>
+    </testcase>
+  </testsuite>
+  <testsuite name="Acceptance" tests="1" failures="0" errors="0" time="24" skipped="0" hostname="example.machine" id="0-0-0-1" timestamp="do not change me">
+    <testcase name="tcase4" time="1" classname="Acceptance" status="">
+    </testcase>
+  </testsuite>
+  <testsuite name="Acceptance" tests="1" failures="0" errors="0" time="24" skipped="0" hostname="example.machine" id="0-0-0-2">
+    <testcase name="tcase5" time="1" classname="Acceptance" status="">
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/client/src/go/toscactl/test/test_data/target.xml
+++ b/client/src/go/toscactl/test/test_data/target.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<testsuites>
+  <testsuite name="Acceptance" tests="3" failures="1" errors="2" time="24" skipped="0" hostname="example.machine" id="0-0-0-0" timestamp="2011-10-17T23:05:06">
+    <testcase name="tcase1" time="1" classname="Acceptance" status="">
+      <failure type="ExecutionResultState.Error" message="TestCase Failed with Error" />
+      <system-out>	some text </system-out>
+    </testcase>
+    <testcase name="tcase2" time="11" classname="Acceptance">
+      <error type="ExecutionResultState.Failed" message="TestCase Failed with Failure" />
+      <system-out>	more text </system-out>
+    </testcase>
+    <testcase name="tcase3" time="11" classname="Acceptance">
+      <error type="ExecutionResultState.Failed" message="TestCase Failed with Failure" />
+      <system-out>	even more text </system-out>
+    </testcase>
+  </testsuite>
+  <testsuite name="Acceptance" tests="1" failures="0" errors="0" time="24" skipped="0" hostname="example.machine" id="0-0-0-1" timestamp="do not change me">
+    <testcase name="tcase4" time="1" classname="Acceptance" status="">
+    </testcase>
+  </testsuite>
+  <testsuite name="Acceptance" tests="1" failures="0" errors="0" time="24" skipped="0" hostname="example.machine" id="0-0-0-2" timestamp="2011-10-17T23:05:06">
+    <testcase name="tcase5" time="1" classname="Acceptance" status="">
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/client/src/go/toscactl/test/xunit.go
+++ b/client/src/go/toscactl/test/xunit.go
@@ -4,30 +4,33 @@ import (
 	"encoding/xml"
 	"io/ioutil"
 	"os"
+	"strings"
 )
 type TestCaseError struct {
-		Text    string `xml:",chardata"`
-		Type    string `xml:"type,attr"`
-		Message string `xml:"message,attr"`
+	//Text    string `xml:",chardata"`
+	Type    string `xml:"type,attr"`
+	Message string `xml:"message,attr"`
 }
 
 
 type Testcase struct {
-	Text      string        `xml:",chardata"`
+	//Text      string        `xml:",chardata"`
 	Name      string        `xml:"name,attr"`
 	Time      string        `xml:"time,attr"`
 	Classname string        `xml:"classname,attr"`
 	Error     TestCaseError `xml:"error"`
+	Failure   TestCaseError `xml:"failure"`
 	SystemOut string        `xml:"system-out"`
 }
 
 type Testsuite struct {
-	Text     string `xml:",chardata"`
+	//Text     string `xml:",chardata"`
 	Name     string `xml:"name,attr"`
 	Tests    int32 `xml:"tests,attr"`
 	Failures int32 `xml:"failures,attr"`
 	Errors   int32 `xml:"errors,attr"`
 	Time     string `xml:"time,attr"`
+	Timestamp string `xml:"timestamp,attr"`
 	Skipped  int32 `xml:"skipped,attr"`
 	Hostname string `xml:"hostname,attr"`
 	ID       string `xml:"id,attr"`
@@ -99,4 +102,24 @@ func ReadTestResults(filePath string) (*Xunit,error){
 	}
 
 	return &xunit,nil
+}
+
+func PatchMissingTimestamp(timestamp string, xunit *Xunit, filePath string) {
+	// Add given value when timestamp is not available as a workaround (implemented in Tosca 15.0+)
+	for idx := range xunit.Testsuite {
+		if xunit.Testsuite[idx].Timestamp == "" {
+			xunit.Testsuite[idx].Timestamp = timestamp
+		}
+	}
+
+	// Reconstruct XML file from marshalled contents
+	byteOutput,_ := xml.MarshalIndent(&xunit, "", "  ")
+	out_s := string(byteOutput)
+	// Handle html newlines and tabs in <system-out>
+	out_s = strings.ReplaceAll(out_s, "&#xA;", "\n")
+	out_s = strings.ReplaceAll(out_s, "&#x9;", "\t")
+	out_s = "<?xml version=\"1.0\"?>\n" + out_s  // Add generic header
+	
+	// Update the original file
+	ioutil.WriteFile(filePath, []byte(out_s), 0644)
 }

--- a/client/src/go/toscactl/test/xunit_test.go
+++ b/client/src/go/toscactl/test/xunit_test.go
@@ -1,0 +1,47 @@
+package test
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPatchMissingTimestamp(t *testing.T) {
+	// Create temp file with original.xml contents
+	tmp_file_path := filepath.Join("test_data", "tmp.xml")
+	tmp_file, err := os.Create(tmp_file_path)
+	if err != nil {
+		t.Error("Cannot create temp file")
+	}
+	defer os.Remove(tmp_file_path)	
+	original_file_path := filepath.Join("test_data", "original.xml")
+	original_file, err := os.Open(original_file_path)
+	io.Copy(tmp_file, original_file)
+
+	// Load and patch
+	var timestamp = "2011-10-17T23:05:06"
+	testResult, err := ReadTestResults(original_file_path)
+	PatchMissingTimestamp(timestamp, testResult, tmp_file_path)
+
+	// Compare output with target
+	f1, err := ioutil.ReadFile(tmp_file_path)
+	if err != nil {
+        t.Error(err)
+    }
+	f2, err := ioutil.ReadFile(filepath.Join("test_data", "target.xml"))
+	if err != nil {
+        t.Error(err)
+    }
+	if !bytes.Equal(f1, f2) {
+		t.Errorf("Files are not equal!\nPatched:\n%s\nTarget:\n%s", string(f1), string(f2))
+	}
+	defer os.Remove(tmp_file.Name())
+
+	// Check timestamp in xunit
+	if testResult.Testsuite[0].Timestamp != timestamp {
+		t.Error("Timestamp not set in testsuite")
+	}
+}

--- a/client/src/go/toscactl/tosca/test.go
+++ b/client/src/go/toscactl/tosca/test.go
@@ -366,7 +366,11 @@ func (t *Provider) getTestReports(testExecutorConfig *TestExecutorConfiguration,
 		}
 
 		// Fix missing timestamp (prior to Tosca 15.0)
-		test.PatchMissingTimestamp(now_s, testResult, testResultFile)
+		err = test.PatchMissingTimestamp(now_s, testResult, testResultFile)
+		if err != nil {
+			return nil,err
+		}
+
 
 		testResults = append(testResults,testResult)
 	}

--- a/client/src/go/toscactl/tosca/test.go
+++ b/client/src/go/toscactl/tosca/test.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/avast/retry-go"
-	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -17,6 +15,9 @@ import (
 	"toscactl/entity"
 	"toscactl/helper"
 	"toscactl/test"
+
+	"github.com/avast/retry-go"
+	log "github.com/sirupsen/logrus"
 )
 const(
     APICreateExecution    = "execution"
@@ -356,11 +357,17 @@ func (t *Provider) getTestReports(testExecutorConfig *TestExecutorConfiguration,
 	if err!=nil {
 		return nil,err
 	}
+	var now = time.Now()
+	var now_s = now.Format(time.RFC3339)
 	for _, testResultFile := range testResultFiles{
 		testResult, err := test.ReadTestResults(testResultFile)
 		if err!=nil {
 			return nil,err
 		}
+
+		// Fix missing timestamp (prior to Tosca 15.0)
+		test.PatchMissingTimestamp(now_s, testResult, testResultFile)
+
 		testResults = append(testResults,testResult)
 	}
 	return testResults,nil


### PR DESCRIPTION
Implemented simple timestamp patching on the incoming xml (xunit) files in the golang client. The timestamp is computed upon reception of the files.

Unmarshalling the previously loaded xunit instead of replacing strings produced wrongly formatted system-output fields within the xml file.